### PR TITLE
 error starting storybook for webcomponents

### DIFF
--- a/packages/storybook/src/executors/utils.ts
+++ b/packages/storybook/src/executors/utils.ts
@@ -14,8 +14,7 @@ export function getStorybookFrameworkPath(uiFramework) {
     '@storybook/html': '@storybook/html/dist/cjs/server/options',
     '@storybook/vue': '@storybook/vue/dist/cjs/server/options',
     '@storybook/vue3': '@storybook/vue3/dist/cjs/server/options',
-    '@storybook/web-components"':
-      '@storybook/web-components"/dist/cjs/server/options',
+    '@storybook/web-components': '@storybook/web-components/dist/cjs/server/options',
   };
 
   if (isStorybookV62onwards(uiFramework)) {


### PR DESCRIPTION
superfluous double quotes prevent getting the correct serveroptions path for starting webcomponents

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Starting storybook for webcomponents does not work. Starting storybook throws error : The "id" argument must be of type string. Received undefined


## Expected Behavior
Start storybook for webcomponents

## Related Issue(s)
https://github.com/nrwl/nx/issues/5985

Fixes #
removed superfluous double quotes